### PR TITLE
feat: support `CursorType` for `async-graphql`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### GraphQL Support
+
+You can use `Pxid` on GraphQL via the `async-graphql` crate.
+Make sure the `graphql` feature is enabled and import `Pxid` for GraphQL.
+
+```rust
+use async_graphql::{Context, InputObject, Result, SimpleObject};
+use pxid::graphql::Pxid;
+
+// -- snip --
+
+#[derive(Debug, InputObject)]
+pub struct PostCreateInput {
+    pub title: String,
+    pub content: String,
+    pub parent_id: Option<Pxid>,
+}
+
+impl PostCreate {
+    pub async fn exec(ctx: &Context<'_>, input: PostCreateInput) -> Result<Self> {
+// -- snip --
+```
+
+> Check out the full example [here][2].
+
 ## Layout
 A prefixed XID fits nicely on a 16 bytes slice thanks to its packed data format.
 
@@ -117,3 +142,4 @@ of context on record association.
 This project is licensed under the MIT License
 
 [1]: https://github.com/rs/xid
+[2]: https://github.com/whizzes/gabble/blob/ca10e295ce1386dd15a8f91f968e7aa8085287c4/crates/server/src/graphql/modules/post/mutation/post_create.rs

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,10 +1,12 @@
-use std::{ops::Deref, str::FromStr};
+use std::ops::Deref;
+use std::str::FromStr;
 
+use async_graphql::connection::CursorType;
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 use serde::{Deserialize, Serialize};
 
 /// `Pxid` is an unique 16 bytes prefixed identifier
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Pxid(crate::Pxid);
 
 impl Pxid {
@@ -50,6 +52,26 @@ impl ScalarType for Pxid {
 impl ToString for Pxid {
     fn to_string(&self) -> String {
         self.0.to_string()
+    }
+}
+
+impl FromStr for Pxid {
+    type Err = crate::error::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::Pxid::from_str(s).map(Self)
+    }
+}
+
+impl CursorType for Pxid {
+    type Error = crate::error::Error;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        Pxid::from_str(s)
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
     }
 }
 


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
