### PR TITLE
fix: use lower order bytes from counter

### DIFF
--- a/src/factory.rs
+++ b/src/factory.rs
@@ -64,3 +64,26 @@ impl Factory {
         Pxid::from_parts(prefix, time, self.machine_id, self.process_id, counter)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factory_never_repeats() {
+        const TRYOUTS: usize = 1000;
+
+        let mut specimen: Vec<Pxid> = Vec::with_capacity(TRYOUTS);
+        let factory = Factory::new().unwrap();
+
+        for _ in 0..TRYOUTS {
+            let id = factory.new_id("test").unwrap();
+            specimen.push(id);
+        }
+
+        for id in specimen.iter() {
+            let count = specimen.iter().filter(|&x| x == id).count();
+            assert_eq!(count, 1);
+        }
+    }
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -272,7 +272,7 @@ impl Pxid {
         bytes[12..=13].copy_from_slice(&process_id.to_be_bytes());
 
         // 3 bytes of increment counter (big endian)
-        bytes[14..].copy_from_slice(&counter.to_be_bytes()[0..=1]);
+        bytes[14..].copy_from_slice(&counter.to_be_bytes()[2..4]);
 
         Ok(Self(bytes))
     }


### PR DESCRIPTION
Use the lower order bytes from the 4 bytes integer (`u32`) when creating an instance of `Pxid`. This way if our counter seed is `15436283` then when adding `1` the sets of bytes
used will be `6284` instead of `1543`.

Given that we use `to_be_bytes` the endianes is guaranteed to be Big Endian so LO bytes
will always match.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
