### PR TITLE
fix(serde): serialization should use `str` over `[u8]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "md5",
  "rand",
  "serde",
+ "serde_json",
  "serde_test",
  "sysctl",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.193", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.176"
+serde_json = "1.0.68"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sysctl = "0.5.5"


### PR DESCRIPTION
Currently `Pxid` deserialize expects a `[u8]` which is not right because JSON payloads,
for instance, represents `Pxid` as a `String` instead.